### PR TITLE
Fix for allowing insecure connections.

### DIFF
--- a/app/src/main/java/com/sbv/linkdroid/Utils.java
+++ b/app/src/main/java/com/sbv/linkdroid/Utils.java
@@ -1,0 +1,59 @@
+package com.sbv.linkdroid;
+
+import android.util.Log;
+
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+public class Utils {
+    private static final String TAG = "Utils";
+
+    private static TrustManager[] trustAllCerts = new TrustManager[]{
+            new X509TrustManager() {
+                @Override
+                public void checkClientTrusted(X509Certificate[] chain, String authType) {
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] chain, String authType) {
+                }
+
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[]{};
+                }
+            }
+    };
+
+    private static HostnameVerifier insecureHostnameVerifier = new HostnameVerifier() {
+        public boolean verify(String hostname, SSLSession session) {
+            return true;
+        }
+    };
+
+    public static SSLSocketFactory createInsecureSslSocketFactory() {
+        try {
+            final SSLContext sslContext = SSLContext.getInstance("SSL");
+            sslContext.init(null, trustAllCerts, new SecureRandom());
+            return sslContext.getSocketFactory();
+        } catch (Exception e) {
+            Log.e(TAG, e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static X509TrustManager getInsecureTrustManager() {
+        return (X509TrustManager) trustAllCerts[0];
+    }
+
+    public static HostnameVerifier getInsecureHostnameVerifier() {
+        return insecureHostnameVerifier;
+    }
+}

--- a/app/src/main/java/com/sbv/linkdroid/api/LinkwardenAPIHandler.java
+++ b/app/src/main/java/com/sbv/linkdroid/api/LinkwardenAPIHandler.java
@@ -12,18 +12,12 @@ import androidx.annotation.NonNull;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.sbv.linkdroid.SettingsFragment;
+import com.sbv.linkdroid.Utils;
 
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import java.util.List;
-
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -46,47 +40,17 @@ public class LinkwardenAPIHandler {
     private final Context context;
     private final APICallback callback;
 
-    private static TrustManager[] trustAllCerts = new TrustManager[] {
-            new X509TrustManager() {
-                @Override
-                public void checkClientTrusted(X509Certificate[] chain, String authType) {}
-
-                @Override
-                public void checkServerTrusted(X509Certificate[] chain, String authType) {}
-
-                @Override
-                public X509Certificate[] getAcceptedIssuers() {
-                    return new X509Certificate[]{};
-                }
-            }
-    };
-
-
-    private static SSLSocketFactory createInsecureSslSocketFactory() {
-        try {
-            final SSLContext sslContext = SSLContext.getInstance("SSL");
-            sslContext.init(null, trustAllCerts, new SecureRandom());
-            return sslContext.getSocketFactory();
-        } catch (Exception e) {
-            Log.e(TAG, e.getMessage(), e);
-            throw new RuntimeException(e);
-        }
-    };
-
-
-    public LinkwardenAPIHandler(Context context, @NonNull APICallback callback){
+    public LinkwardenAPIHandler(Context context, @NonNull APICallback callback) {
         this.context = context;
         this.callback = callback;
         SharedPreferences preferences = getDefaultSharedPreferences(context);
         this.baseURL = preferences.getString("BASE_URL", "");
-        if (preferences.getBoolean("ALLOW_INSECURE_CONNECTION", false)){
-            X509TrustManager insecureTrustManager = (X509TrustManager) trustAllCerts[0];
+        if (preferences.getBoolean("ALLOW_INSECURE_CONNECTION", false)) {
             this.client = new OkHttpClient.Builder()
-                    .sslSocketFactory(createInsecureSslSocketFactory(), insecureTrustManager)
+                    .sslSocketFactory(Utils.createInsecureSslSocketFactory(), Utils.getInsecureTrustManager())
                     .hostnameVerifier((hostname, session) -> true)
                     .build();
-        }
-        else {
+        } else {
             this.client = new OkHttpClient();
         }
 //        testAuthInBackground();

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -84,7 +84,7 @@
         app:layout="@layout/preference_switch_aligned"
         android:layout_marginBottom="0dp"/>
 
-    <!-- External Browser Switch Preference -->
+    <!-- Allow Insecure Connection Preference -->
     <SwitchPreference
         app:key="ALLOW_INSECURE_CONNECTION"
         app:title="@string/allow_insecure_connection_title"


### PR DESCRIPTION
This fixes the following issues even if the setting to allow insecure connections was toggled on:
1. The dashboard page not loading.
2. The showing of the connection error popup.